### PR TITLE
Fix/dont run on distributable folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .private
 dist
+deploy
 node_modules
 package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 versiona.js
 node_modules
 src
+deploy
 .gitignore
 .idea
 .travis.yml

--- a/package.json
+++ b/package.json
@@ -7,6 +7,14 @@
   "license": "MIT",
   "repository": "github:alextremp/versiona",
   "bugs": "https://github.com/alextremp/versiona/issues",
+  "keywords": [
+    "travis",
+    "ci",
+    "deploy",
+    "publish",
+    "version",
+    "semver"
+  ],
   "scripts": {
     "clean": "rm -Rf dist",
     "phoenix": "rm -Rf node_modules && rm -Rf package-lock.json && npm i",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "sui-lint js",
     "check": "npm run lint",
     "build": "npm run clean && babel src/main --out-dir dist",
-    "version": "npm run build && node versiona.js"
+    "version": "rm -Rf deploy && babel src/main --out-dir deploy && node versiona.js"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.5",

--- a/versiona.js
+++ b/versiona.js
@@ -1,4 +1,4 @@
-const versiona = require('./dist/index').default
+const versiona = require('./deploy/index').default
 
 versiona({
   repoOrg: 'alextremp',


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Changes:
- add keywords
- fix: don't run into 'dist' folder when auto-publishing this lib as it will remove the dist folder when running the publish prepack instructions. Auto-publish has to create a new folder to be ran inside of it.